### PR TITLE
fix(frb_generated): fix dco_decode_xx function when building failed

### DIFF
--- a/lib/rust/frb_generated.dart
+++ b/lib/rust/frb_generated.dart
@@ -317,7 +317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformInt64 dco_decode_i_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dcoDecodeI64(raw);
+    return dcoDecodeI64(raw as int);
   }
 
   @protected
@@ -392,7 +392,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigInt dco_decode_u_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dcoDecodeU64(raw);
+    return dcoDecodeU64(raw as int);
   }
 
   @protected


### PR DESCRIPTION
When i trying build project,found that error in ```frb_generated.dart``` 
```shell
The argument type 'dynamic' can't be assigned to the parameter type 'int'
```